### PR TITLE
Improve error handling in log parsing

### DIFF
--- a/src/LogManagement/LogEntryIterator.h
+++ b/src/LogManagement/LogEntryIterator.h
@@ -4,6 +4,8 @@
 #include "LogEntry.h"
 #include "LogUtils.h"
 
+#include <QDebug>
+
 #include <boost/heap/priority_queue.hpp>
 
 
@@ -249,7 +251,18 @@ private:
 
         while (line.has_value())
         {
-            auto parts = splitLine(line.value(), format);
+            QStringList parts;
+            try
+            {
+                parts = splitLine(line.value(), format);
+            }
+            catch (const std::exception& ex)
+            {
+                qWarning() << "Failed to split line:" << line.value() << ":" << ex.what();
+                line = (heapItem.log.get()->*(straight ? &Log::nextLine : &Log::prevLine))();
+                continue;
+            }
+
             if (!checkFormat(parts, format) || parts.size() <= format->timeFieldIndex)
             {
                 if constexpr (straight)
@@ -288,7 +301,16 @@ private:
                 entry.line.prepend(line.value());
             }
 
-            entry.time = parseTime(parts[format->timeFieldIndex], format);
+            try
+            {
+                entry.time = parseTime(parts[format->timeFieldIndex], format);
+            }
+            catch (const std::exception& ex)
+            {
+                qWarning() << "Failed to parse time in line:" << line.value() << ":" << ex.what();
+                line = (heapItem.log.get()->*(straight ? &Log::nextLine : &Log::prevLine))();
+                continue;
+            }
             for (size_t i = 0, fieldCount = 0; i < format->fields.size(); ++i)
             {
                 const auto& field = format->fields[i];

--- a/src/LogManagement/LogStorage.cpp
+++ b/src/LogManagement/LogStorage.cpp
@@ -52,7 +52,16 @@ void LogStorage::finalize()
                 break;
             }
 
-            parts = splitLine(line.value(), lastLog.second.format);
+            try
+            {
+                parts = splitLine(line.value(), lastLog.second.format);
+            }
+            catch (const std::exception& ex)
+            {
+                qWarning() << "Failed to split line in" << lastLog.second.filename << ":" << ex.what();
+                continue;
+            }
+
             if (parts.size() <= lastLog.second.format->timeFieldIndex)
                 continue;
         }
@@ -61,8 +70,15 @@ void LogStorage::finalize()
         if (parts.empty())
             continue;
 
-        auto time = parseTime(parts[lastLog.second.format->timeFieldIndex], lastLog.second.format);
-        maxTime = std::max(maxTime, time + std::chrono::milliseconds(1));
+        try
+        {
+            auto time = parseTime(parts[lastLog.second.format->timeFieldIndex], lastLog.second.format);
+            maxTime = std::max(maxTime, time + std::chrono::milliseconds(1));
+        }
+        catch (const std::exception& ex)
+        {
+            qWarning() << "Failed to parse time in" << lastLog.second.filename << ":" << ex.what();
+        }
     }
 }
 

--- a/src/LogManagement/LogUtils.cpp
+++ b/src/LogManagement/LogUtils.cpp
@@ -192,7 +192,10 @@ std::chrono::system_clock::time_point parseTime(const QString& timeStr, const st
         std::istringstream ss(std::string{ baseStr });
         ss >> std::chrono::parse(format->timeMask.toStdString(), tp);
         if (!ss)
-            throw std::runtime_error("Failed to parse base time part");
+        {
+            throw std::runtime_error("Failed to parse time '" + input + "' using mask '" +
+                                     format->timeMask.toStdString() + "'");
+        }
     }
 
     if (!fracStr.empty() && format->timeFractionalDigits > 0)


### PR DESCRIPTION
## Summary
- handle parsing errors gracefully when iterating logs
- catch failures during log storage finalization
- provide clearer error message when parsing timestamps

## Testing
- `cmake -B build -S .` *(fails: Could NOT find ZLIB)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_687fe39a9bcc8323bf0cf3be53abd169