### PR TITLE
Replace nlohmann_json with Qt JSON

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,12 +50,6 @@ jobs:
           key: ${{ runner.os }}-boost-1.88.0
           path: deps/win64/Release/boost
 
-      - name: Cache nlohmann_json
-        id: cache-nlohmann
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-nlohmann-3.12.0
-          path: deps/win64/Release/nlohmann_json
 
       - name: Download ZLib
         if: steps.cache-zlib.outputs.cache-hit != 'true'
@@ -136,32 +130,6 @@ jobs:
           ./b2 install --prefix=$installPath --build-type=complete --layout=versioned address-model=64 variant=release link=static,shared runtime-link=static,shared threading=multi --with-headers
           cd ../../..
 
-      - name: Download nlohmann_json
-        if: steps.cache-nlohmann.outputs.cache-hit != 'true'
-        uses: robinraju/release-downloader@v1
-        with:
-          repository: 'nlohmann/json'
-          tag: 'v3.12.0'
-          zipBall: true
-          out-file-path: 'external/libs'
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build nlohmann_json
-        if: steps.cache-nlohmann.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $installPath = Join-Path $Env:GITHUB_WORKSPACE 'deps/win64/Release/nlohmann_json'
-          cd external/libs
-          $zip = Get-ChildItem -Filter 'json-*.zip' | Select-Object -First 1
-          7z x $zip.FullName
-          Remove-Item $zip.FullName
-          $dir = Get-ChildItem -Directory | Where-Object { $_.Name -like 'nlohmann-json-*' } | Select-Object -First 1
-          cd $dir.Name
-          cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DJSON_BuildTests=OFF -DCMAKE_INSTALL_PREFIX="$installPath"
-          cmake --build build --config Release --parallel
-          cmake --install build --config Release
-          cd ../../..
 
       - name: Configure
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,6 @@ jobs:
           key: ${{ runner.os }}-boost-1.88.0
           path: deps/win64/Release/boost
 
-      - name: Cache nlohmann_json
-        id: cache-nlohmann
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-nlohmann-3.12.0
-          path: deps/win64/Release/nlohmann_json
 
       - name: Download ZLib
         if: steps.cache-zlib.outputs.cache-hit != 'true'
@@ -133,32 +127,6 @@ jobs:
           ./b2 install --prefix=$installPath --build-type=complete --layout=versioned address-model=64 variant=release link=static,shared runtime-link=static,shared threading=multi --with-headers
           cd ../../..
 
-      - name: Download nlohmann_json
-        if: steps.cache-nlohmann.outputs.cache-hit != 'true'
-        uses: robinraju/release-downloader@v1
-        with:
-          repository: 'nlohmann/json'
-          tag: 'v3.12.0'
-          zipBall: true
-          out-file-path: 'external/libs'
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build nlohmann_json
-        if: steps.cache-nlohmann.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $installPath = Join-Path $Env:GITHUB_WORKSPACE 'deps/win64/Release/nlohmann_json'
-          cd external/libs
-          $zip = Get-ChildItem -Filter 'json-*.zip' | Select-Object -First 1
-          7z x $zip.FullName
-          Remove-Item $zip.FullName
-          $dir = Get-ChildItem -Directory | Where-Object { $_.Name -like 'nlohmann-json-*' } | Select-Object -First 1
-          cd $dir.Name
-          cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DJSON_BuildTests=OFF -DCMAKE_INSTALL_PREFIX="$installPath"
-          cmake --build build --config Release --parallel
-          cmake --install build --config Release
-          cd ../../..
 
       - name: Configure
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ check_local_hints()
 find_package(Qt6 COMPONENTS Core Gui Widgets REQUIRED)
 find_package(QuaZip-Qt6 COMPONENTS QuaZip)
 find_package(Boost COMPONENTS headers REQUIRED)
-find_package(nlohmann_json REQUIRED)
 
 file(GLOB ts ${CMAKE_CURRENT_SOURCE_DIR}/translations/*)
 if (${ts} NOT STREQUAL "" AND QT6::LINGUIST_TOOLS_FOUND)
@@ -73,7 +72,6 @@ target_link_libraries(${PROJECT_NAME}
         Qt6::Widgets
         QuaZip::QuaZip
         Boost::headers
-        nlohmann_json::nlohmann_json
 )
 
 get_target_property(_qt5_qmake_location Qt::qmake IMPORTED_LOCATION)


### PR DESCRIPTION
## Summary
- use `QJsonDocument` for parsing JSON log entries
- drop the nlohmann_json dependency
- use iterator lookup when traversing JSON fields

## Testing
- `cmake ..` *(fails: could not find package Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_688275334e008323847c5b3e3324e94f