### PR TITLE
Restore filtered iteration for strict filters

### DIFF
--- a/src/LogManagement/FilteredLogIterator.h
+++ b/src/LogManagement/FilteredLogIterator.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "LogEntryIterator.h"
+#include "../LogFilter.h"
+
+// Iterator wrapper that yields only entries matching a given LogFilter
+
+template<bool straight = true>
+class FilteredLogIterator
+{
+public:
+    FilteredLogIterator(const std::shared_ptr<LogEntryIterator<straight>>& baseIterator,
+                        const LogFilter& logFilter)
+        : iterator(baseIterator),
+          filter(logFilter)
+    {
+        if (iterator)
+            advance();
+    }
+
+    bool hasLogs() const
+    {
+        return iterator && current.has_value();
+    }
+
+    std::optional<LogEntry> next()
+    {
+        if (!hasLogs())
+            return std::nullopt;
+
+        auto result = std::move(current);
+        advance();
+        return result;
+    }
+
+    bool isValueAhead(const std::chrono::system_clock::time_point& time) const
+    {
+        return iterator->isValueAhead(time);
+    }
+
+    std::chrono::system_clock::time_point getCurrentTime() const
+    {
+        return iterator->getCurrentTime();
+    }
+
+    MergeHeapCache getCache() const
+    {
+        return iterator->getCache();
+    }
+
+private:
+    void advance()
+    {
+        current.reset();
+        if (!iterator)
+            return;
+
+        while (auto entry = iterator->next())
+        {
+            if (filter.check(*entry))
+            {
+                current = std::move(entry);
+                break;
+            }
+        }
+    }
+
+private:
+    std::shared_ptr<LogEntryIterator<straight>> iterator;
+    LogFilter filter;
+    std::optional<LogEntry> current;
+};
+

--- a/src/LogManagement/FilteredLogIterator.h
+++ b/src/LogManagement/FilteredLogIterator.h
@@ -3,16 +3,14 @@
 #include "LogEntryIterator.h"
 #include "../LogFilter.h"
 
-// Iterator wrapper that yields only entries matching a given LogFilter
 
 template<bool straight = true>
 class FilteredLogIterator
 {
 public:
-    FilteredLogIterator(const std::shared_ptr<LogEntryIterator<straight>>& baseIterator,
-                        const LogFilter& logFilter)
-        : iterator(baseIterator),
-          filter(logFilter)
+    FilteredLogIterator(const std::shared_ptr<LogEntryIterator<straight>>& baseIterator, const LogFilter& logFilter) :
+        iterator(baseIterator),
+        filter(logFilter)
     {
         if (iterator)
             advance();

--- a/src/LogManagement/LogEntryIterator.h
+++ b/src/LogManagement/LogEntryIterator.h
@@ -28,6 +28,8 @@ template<bool straight = true>
 class LogEntryIterator
 {
 public:
+    static const bool IsStraight = straight;
+
     struct HeapItem
     {
         const LogStorage::LogMetaEntry* metadata;

--- a/src/LogService.h
+++ b/src/LogService.h
@@ -53,6 +53,19 @@ public:
     }
 
     template<typename Iterator>
+    int requestLogEntries(const std::shared_ptr<Iterator>& iterator, int entryCount, const LogFilter& filter)
+    {
+        if (!logManager || !iterator || entryCount <= 0 || !iterator->hasLogs())
+            throw std::runtime_error("Invalid log entry request parameters.");
+
+        int index = nextRequestIndex++;
+        dataRequests->emplace_back(index, std::make_shared<FilteredLogIterator<Iterator::IsStraight>>(iterator, filter), entryCount);
+        QMetaObject::invokeMethod(this, "handleDataRequest", Qt::QueuedConnection);
+
+        return index;
+    }
+
+    template<typename Iterator>
     int requestLogEntries(const std::shared_ptr<Iterator>& iterator, int entryCount, const std::chrono::system_clock::time_point& until)
     {
         if (!logManager || !iterator || entryCount <= 0 || !iterator->hasLogs())
@@ -60,6 +73,19 @@ public:
 
         int index = nextRequestIndex++;
         dataRequests->emplace_back(index, iterator, entryCount, until);
+        QMetaObject::invokeMethod(this, "handleDataRequest", Qt::QueuedConnection);
+
+        return index;
+    }
+
+    template<typename Iterator>
+    int requestLogEntries(const std::shared_ptr<Iterator>& iterator, int entryCount, const std::chrono::system_clock::time_point& until, const LogFilter& filter)
+    {
+        if (!logManager || !iterator || entryCount <= 0 || !iterator->hasLogs())
+            throw std::runtime_error("Invalid log entry request parameters.");
+
+        int index = nextRequestIndex++;
+        dataRequests->emplace_back(index, std::make_shared<FilteredLogIterator<Iterator::IsStraight>>(iterator, filter), entryCount, until);
         QMetaObject::invokeMethod(this, "handleDataRequest", Qt::QueuedConnection);
 
         return index;

--- a/src/LogService.h
+++ b/src/LogService.h
@@ -2,6 +2,7 @@
 
 #include "LogManagement/LogManager.h"
 #include "LogManagement/Session.h"
+#include "LogManagement/FilteredLogIterator.h"
 #include "ThreadSafePtr.h"
 #include "LogFilter.h"
 
@@ -119,7 +120,9 @@ private:
         int index;
         std::variant<
             std::shared_ptr<LogEntryIterator<true>>,
-            std::shared_ptr<LogEntryIterator<false>>
+            std::shared_ptr<LogEntryIterator<false>>,
+            std::shared_ptr<FilteredLogIterator<true>>,
+            std::shared_ptr<FilteredLogIterator<false>>
             > iterator;
         int entriesCount;
         std::optional<std::chrono::system_clock::time_point> until;

--- a/src/LogView/FilteredLogModel.cpp
+++ b/src/LogView/FilteredLogModel.cpp
@@ -2,11 +2,10 @@
 
 #include <chrono>
 
-FilteredLogModel::FilteredLogModel(LogService* logService, const LogFilter& filter, QObject* parent)
-    : LogModel(logService, parent),
-      filter(filter)
-{
-}
+FilteredLogModel::FilteredLogModel(LogService* logService, const LogFilter& filter, QObject* parent) :
+    LogModel(logService, parent),
+    filter(filter)
+{}
 
 void FilteredLogModel::fetchUpMore()
 {

--- a/src/LogView/FilteredLogModel.cpp
+++ b/src/LogView/FilteredLogModel.cpp
@@ -1,0 +1,31 @@
+#include "FilteredLogModel.h"
+
+#include <chrono>
+
+FilteredLogModel::FilteredLogModel(LogService* logService, const LogFilter& filter, QObject* parent)
+    : LogModel(logService, parent),
+      filter(filter)
+{
+}
+
+void FilteredLogModel::fetchUpMore()
+{
+    LogModel::fetchUpMore(filter);
+}
+
+void FilteredLogModel::fetchDownMore()
+{
+    LogModel::fetchDownMore(filter);
+}
+
+const LogFilter& FilteredLogModel::getFilter() const
+{
+    return filter;
+}
+
+void FilteredLogModel::setFilter(const LogFilter& newFilter)
+{
+    filter = newFilter;
+    goToTime(std::chrono::system_clock::time_point::min());
+}
+

--- a/src/LogView/FilteredLogModel.h
+++ b/src/LogView/FilteredLogModel.h
@@ -3,9 +3,11 @@
 #include "LogModel.h"
 #include "../LogFilter.h"
 
+
 class FilteredLogModel : public LogModel
 {
     Q_OBJECT
+
 public:
     explicit FilteredLogModel(LogService* logService, const LogFilter& filter, QObject* parent = nullptr);
 

--- a/src/LogView/FilteredLogModel.h
+++ b/src/LogView/FilteredLogModel.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "LogModel.h"
+#include "../LogFilter.h"
+
+class FilteredLogModel : public LogModel
+{
+    Q_OBJECT
+public:
+    explicit FilteredLogModel(LogService* logService, const LogFilter& filter, QObject* parent = nullptr);
+
+    void fetchUpMore() override;
+    void fetchDownMore() override;
+
+    const LogFilter& getFilter() const;
+    void setFilter(const LogFilter& newFilter);
+
+private:
+    LogFilter filter;
+};
+

--- a/src/LogView/LogFilterModel.cpp
+++ b/src/LogView/LogFilterModel.cpp
@@ -1,8 +1,10 @@
 #include "LogFilterModel.h"
 
 #include "LogModel.h"
+#include "FilteredLogModel.h"
 
 #include <QRegularExpression>
+#include <chrono>
 
 
 LogFilterModel::LogFilterModel(QObject *parent) : QSortFilterProxyModel(parent)
@@ -12,29 +14,87 @@ LogFilterModel::LogFilterModel(QObject *parent) : QSortFilterProxyModel(parent)
 
 void LogFilterModel::setFilterWildcard(int column, const QString& pattern)
 {
+    double before = rowCount();
+    auto it = filterEstimates.find(column);
+    if (before == 0)
+        before = it != filterEstimates.end() ? it->second : 1;
+    else if (it != filterEstimates.end())
+        before *= it->second;
+
     if (pattern.isEmpty())
         columnFilters.erase(column);
     else
         columnFilters[column] = QRegularExpression{ QRegularExpression::wildcardToRegularExpression(pattern, QRegularExpression::WildcardConversionOption::UnanchoredWildcardConversion) };
+
     invalidateFilter();
+    double after = rowCount();
+
+    if (pattern.isEmpty())
+        filterEstimates.erase(column);
+    else
+        filterEstimates[column] = after > 0 ? before / after : before;
+
+    updateSourceModel();
 }
 
 void LogFilterModel::setFilterRegularExpression(int column, const QString& pattern)
 {
+    double before = rowCount();
+    auto it = filterEstimates.find(column);
+    if (before == 0)
+        before = it != filterEstimates.end() ? it->second : 1;
+    else if (it != filterEstimates.end())
+        before *= it->second;
+
     if (pattern.isEmpty())
         columnFilters.erase(column);
     else
         columnFilters[column] = QRegularExpression(pattern);
+
     invalidateFilter();
+    double after = rowCount();
+
+    if (pattern.isEmpty())
+        filterEstimates.erase(column);
+    else
+        filterEstimates[column] = after > 0 ? before / after : before;
+
+    updateSourceModel();
 }
 
 void LogFilterModel::setVariantList(int column, const QStringList& values)
 {
+    double before = rowCount();
+    auto it = filterEstimates.find(column);
+    if (before == 0)
+        before = it != filterEstimates.end() ? it->second : 1;
+    else if (it != filterEstimates.end())
+        before *= it->second;
+
     if (values.isEmpty())
         variants.erase(column);
     else
         variants[column] = std::unordered_set<QString>{ values.begin(), values.end() };
+
     invalidateFilter();
+    double after = rowCount();
+
+    if (values.isEmpty())
+        filterEstimates.erase(column);
+    else
+        filterEstimates[column] = after > 0 ? before / after : before;
+
+    updateSourceModel();
+}
+
+void LogFilterModel::setSourceModel(QAbstractItemModel* model)
+{
+    baseModel = qobject_cast<LogModel*>(model);
+    filteredModel.reset();
+    filterEstimates.clear();
+    QSortFilterProxyModel::setSourceModel(model);
+
+    emit sourceModelChanged(model);
 }
 
 LogFilter LogFilterModel::exportFilter() const
@@ -106,4 +166,61 @@ bool LogFilterModel::filterAcceptsRow(int source_row, const QModelIndex& source_
     }
 
     return true;
+}
+
+void LogFilterModel::ensureFilteredModel()
+{
+    if (filteredModel)
+        return;
+
+    if (exportFilter().isEmpty())
+        return;
+
+    updateSourceModel();
+}
+
+void LogFilterModel::updateSourceModel()
+{
+    if (!baseModel)
+        return;
+
+    auto filter = exportFilter();
+    double totalRate = 1.0;
+    for (const auto& est : filterEstimates)
+        totalRate *= est.second;
+
+    if (filter.isEmpty() || !baseModel->isFulled() || totalRate <= 1.0)
+    {
+        if (filteredModel)
+        {
+            filteredModel.reset();
+            QSortFilterProxyModel::setSourceModel(baseModel);
+            invalidateFilter();
+            emit sourceModelChanged(baseModel);
+        }
+        return;
+    }
+
+    constexpr double recreateThreshold = 10.0;
+    if (filteredModel && totalRate < recreateThreshold)
+    {
+        filteredModel->setFilter(filter);
+    }
+    else
+    {
+        filteredModel = std::make_unique<FilteredLogModel>(baseModel->getService(), filter);
+        filteredModel->goToTime(std::chrono::system_clock::time_point::min());
+    }
+
+    QSortFilterProxyModel::setSourceModel(filteredModel.get());
+    clearFilters();
+    invalidateFilter();
+    emit sourceModelChanged(filteredModel.get());
+}
+
+void LogFilterModel::clearFilters()
+{
+    columnFilters.clear();
+    variants.clear();
+    filterEstimates.clear();
 }

--- a/src/LogView/LogFilterModel.h
+++ b/src/LogView/LogFilterModel.h
@@ -5,8 +5,12 @@
 #include <QSortFilterProxyModel>
 #include <QRegularExpression>
 
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
+
+class LogModel;
+class FilteredLogModel;
 
 
 class LogFilterModel : public QSortFilterProxyModel
@@ -20,14 +24,26 @@ public:
     void setFilterRegularExpression(int column, const QString& pattern);
     void setVariantList(int column, const QStringList& values);
 
+    void setSourceModel(QAbstractItemModel* sourceModel) override;
+
     LogFilter exportFilter() const;
 
     bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
 
+    void ensureFilteredModel();
+
 signals:
     void handleError(const QString& message);
+    void sourceModelChanged(QAbstractItemModel* model);
 
 private:
+    void updateSourceModel();
+    void clearFilters();
+
     std::unordered_map<int, QRegularExpression> columnFilters;
     std::unordered_map<int, std::unordered_set<QString>> variants;
+    std::unordered_map<int, double> filterEstimates;
+
+    LogModel* baseModel = nullptr;
+    std::unique_ptr<FilteredLogModel> filteredModel;
 };

--- a/src/LogView/LogModel.h
+++ b/src/LogView/LogModel.h
@@ -9,6 +9,8 @@
 #include <deque>
 #include <set>
 
+class LogFilter;
+
 
 class LogModel : public QAbstractItemModel
 {
@@ -34,10 +36,12 @@ public:
     void goToTime(const std::chrono::system_clock::time_point& time);
 
     bool canFetchUpMore() const;
-    void fetchUpMore();
+    virtual void fetchUpMore();
 
     bool canFetchDownMore() const;
-    void fetchDownMore();
+    virtual void fetchDownMore();
+
+    bool isFulled() const;
 
     const std::vector<Format::Field>& getFields() const;
     const std::unordered_set<QVariant, VariantHash> availableValues(int section) const;
@@ -66,6 +70,8 @@ public:
 
     Qt::ItemFlags flags(const QModelIndex& index) const override;
 
+    LogService* getService() const;
+
 signals:
     void startPageSwap();
     void endPageSwap(int rows);
@@ -77,6 +83,14 @@ signals:
 public slots:
     void handleIterator(int, bool);
     void handleData(int);
+
+protected:
+    void fetchUpMore(const LogFilter& filter);
+    void fetchDownMore(const LogFilter& filter);
+
+private:
+    void fetchUpMoreImpl(const std::shared_ptr<LogEntryIterator<false>>& it);
+    void fetchDownMoreImpl(const std::shared_ptr<LogEntryIterator<true>>& it);
 
 private:
     struct LogItem

--- a/src/LogView/LogView.h
+++ b/src/LogView/LogView.h
@@ -3,6 +3,9 @@
 #include <QAbstractItemModel>
 #include <QTreeView>
 
+class LogModel;
+class LogFilterModel;
+
 
 class LogView : public QTreeView
 {
@@ -30,4 +33,6 @@ private:
 
 private:
     std::optional<QModelIndex> lastScrollPosition;
+    LogModel* currentLogModel = nullptr;
+    LogFilterModel* currentProxyModel = nullptr;
 };


### PR DESCRIPTION
## Summary
- estimate filter tightness by comparing row counts before and after applying new filters
- refresh or recreate the filtered model only when combined filter rates exceed a threshold
- refactor fetch helpers and skip data requests when filter-empty views would trigger unnecessary loads
- scale per-column impact estimates by prior ratios for more accurate unfiltered baselines
- treat a zero baseline row count as one to avoid skewing filter impact estimates
- use existing column estimate when the model reports zero rows so filter ratios stay accurate

## Testing
- `apt-get install -y qt6-base-dev`
- `cmake -S . -B build` *(fails: Could NOT find Boost; Could not find QuaZip-Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_689c56c809088323b0b6b1e9b57c9ef2