### PR TITLE
Run unit tests in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,9 @@ jobs:
       - name: Build
         run: cmake --build build --config Release --parallel
 
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure -C Release
+
       - name: Create artifacts
         run: cmake --build build --target release_packet
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,10 @@ jobs:
         run: cmake --build build --config Release --parallel
 
       - name: Run tests
-        run: ctest --test-dir build --output-on-failure -C Release
+        shell: pwsh
+        run: |
+          $env:PATH = "${env:QT_ROOT_DIR}\bin;${env:GITHUB_WORKSPACE}\deps\win64\Release\zlib\bin;${env:GITHUB_WORKSPACE}\deps\win64\Release\quazip\bin;$env:PATH"
+          ctest --test-dir build --output-on-failure -C Release
 
       - name: Create artifacts
         run: cmake --build build --target release_packet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,9 @@ jobs:
       - name: Build
         run: cmake --build build --config Release --parallel
 
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure -C Release
+
       - name: Create artifacts
         run: cmake --build build --target release_packet
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,10 @@ jobs:
         run: cmake --build build --config Release --parallel
 
       - name: Run tests
-        run: ctest --test-dir build --output-on-failure -C Release
+        shell: pwsh
+        run: |
+          $env:PATH = "${env:QT_ROOT_DIR}\bin;${env:GITHUB_WORKSPACE}\deps\win64\Release\zlib\bin;${env:GITHUB_WORKSPACE}\deps\win64\Release\quazip\bin;$env:PATH"
+          ctest --test-dir build --output-on-failure -C Release
 
       - name: Create artifacts
         run: cmake --build build --target release_packet


### PR DESCRIPTION
## Summary
- run ctest during build pipeline
- run ctest during release pipeline

## Testing
- `cmake -DZLIB_ROOT=/usr -DZLIB_LIBRARY=/usr/lib/x86_64-linux-gnu/libz.so .. && make -j$(nproc)` *(fails: QDateTime::toStdSysMilliseconds missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c0bf025c83239adf56160756464b