### PR TITLE
Add unit tests for log filtering model

### DIFF
--- a/tests/LogFilterModelTest.cpp
+++ b/tests/LogFilterModelTest.cpp
@@ -1,0 +1,160 @@
+#include <QSignalSpy>
+#include <QBuffer>
+#include <QTextStream>
+#include <QStandardItemModel>
+#include <QtTest/QtTest>
+
+#include "Application.h"
+#include "LogService.h"
+#include "LogView/LogFilterModel.h"
+#include "LogView/LogModel.h"
+#include "LogView/FilteredLogModel.h"
+#include "Settings.h"
+#include "LogView/LogViewUtils.h"
+
+static std::chrono::system_clock::time_point toTimePoint(const QDateTime &dt)
+{
+    return std::chrono::system_clock::time_point{ std::chrono::milliseconds{ dt.toMSecsSinceEpoch() } };
+}
+class LogFilterModelTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+    void testFilterWildcard();
+    void testVariantList();
+    void testFilteredModelCreated();
+
+private:
+    Application *app = nullptr;
+    LogService *logService = nullptr;
+    LogModel *model = nullptr;
+    QDateTime firstTime;
+    QString entryTemplate = "msg%1";
+    int entryCount = 5;
+};
+
+void LogFilterModelTest::initTestCase()
+{
+    app = qobject_cast<Application *>(qApp);
+    QVERIFY(app);
+    logService = app->getLogService();
+
+    Settings settings;
+    settings.setValue(LogViewSettings + "/blockSize", entryCount);
+    settings.setValue(LogViewSettings + "/blockCount", 1);
+
+    QByteArray data;
+    QBuffer buffer(&data);
+    QVERIFY(buffer.open(QIODevice::WriteOnly));
+    QTextStream out(&buffer);
+
+    QDateTime baseTime = QDateTime::fromString("2023-01-01 00:00:00", "yyyy-MM-dd HH:mm:ss");
+    firstTime = baseTime;
+    QDateTime lastTime;
+    for (int i = 0; i < entryCount; ++i)
+    {
+        QString msg = entryTemplate.arg(i);
+        QString module = (i % 2 == 0) ? "modA" : "modB";
+        QDateTime entryTime = baseTime.addSecs(i);
+        out << entryTime.toString("yyyy-MM-dd HH:mm:ss.zzz")
+            << ';' << module << ";1;1;info;" << msg << "\n";
+        lastTime = entryTime;
+    }
+    buffer.close();
+
+    std::shared_ptr<Format> format = std::make_shared<Format>();
+    format->name = "TestFormat";
+    format->extension = ".csv";
+    format->separator = ";";
+    format->timeFieldIndex = 0;
+    format->timeMask = "%F %H:%M:%S";
+    format->timeFractionalDigits = 3;
+    for (int i = 0; i < 6; ++i)
+    {
+        Format::Field f;
+        f.name = QString::number(i);
+        f.regex = QRegularExpression(".*");
+        f.type = QMetaType::QString;
+        format->fields.push_back(f);
+    }
+    app->getFormatManager().addFormat(format);
+
+    logService->openBuffer(data, "test.csv", QStringList() << "TestFormat");
+    logService->createSession(logService->getLogManager()->getModules(),
+                              toTimePoint(firstTime),
+                              toTimePoint(lastTime));
+
+    model = new LogModel(logService, this);
+    QSignalSpy resetSpy(model, &QAbstractItemModel::modelReset);
+    model->goToTime(firstTime);
+    QVERIFY(resetSpy.wait(10 * 1000));
+    QCOMPARE(model->rowCount(), entryCount);
+}
+
+void LogFilterModelTest::testFilterWildcard()
+{
+    QStandardItemModel source(entryCount, 7);
+    source.setHeaderData(6, Qt::Horizontal, QStringLiteral("message"));
+    for (int i = 0; i < entryCount; ++i)
+        source.setData(source.index(i, 6), entryTemplate.arg(i));
+
+    LogFilterModel filterModel;
+    filterModel.setSourceModel(&source);
+    filterModel.setFilterWildcard(6, "*1");
+
+    QCOMPARE(filterModel.rowCount(), 1);
+    QModelIndex idx = filterModel.index(0, 6);
+    QCOMPARE(filterModel.data(idx).toString(), entryTemplate.arg(1));
+}
+
+void LogFilterModelTest::testVariantList()
+{
+    QStandardItemModel source(entryCount, 7);
+    source.setHeaderData(2, Qt::Horizontal, QStringLiteral("field1"));
+    for (int i = 0; i < entryCount; ++i)
+    {
+        QString module = (i % 2 == 0) ? "modA" : "modB";
+        source.setData(source.index(i, 2), module);
+    }
+
+    LogFilterModel filterModel;
+    filterModel.setSourceModel(&source);
+    filterModel.setVariantList(2, QStringList() << "modA");
+
+    int expected = (entryCount + 1) / 2;
+    QCOMPARE(filterModel.rowCount(), expected);
+    for (int i = 0; i < filterModel.rowCount(); ++i)
+    {
+        QModelIndex idx = filterModel.index(i, 2);
+        QCOMPARE(filterModel.data(idx).toString(), QStringLiteral("modA"));
+    }
+
+    LogFilter filter = filterModel.exportFilter();
+    LogEntry okEntry; okEntry.values.emplace("field1", QStringLiteral("modA"));
+    LogEntry badEntry; badEntry.values.emplace("field1", QStringLiteral("modB"));
+    QVERIFY(filter.check(okEntry));
+    QVERIFY(!filter.check(badEntry));
+}
+
+void LogFilterModelTest::testFilteredModelCreated()
+{
+    LogFilterModel filterModel;
+    filterModel.setSourceModel(model);
+    QSignalSpy spy(&filterModel, &LogFilterModel::sourceModelChanged);
+
+    filterModel.setVariantList(2, QStringList() << "modA");
+
+    QCOMPARE(spy.count(), 1);
+    QVERIFY(qobject_cast<FilteredLogModel*>(filterModel.sourceModel()));
+}
+
+int main(int argc, char **argv)
+{
+    Application app(argc, argv);
+    LogFilterModelTest tc;
+    return QTest::qExec(&tc, argc, argv);
+}
+
+#include "LogFilterModelTest.moc"

--- a/tests/LogModelTest.cpp
+++ b/tests/LogModelTest.cpp
@@ -9,6 +9,10 @@
 #include "LogView/LogViewUtils.h"
 #include "Settings.h"
 
+static std::chrono::system_clock::time_point toTimePoint(const QDateTime &dt)
+{
+    return std::chrono::system_clock::time_point{ std::chrono::milliseconds{ dt.toMSecsSinceEpoch() } };
+}
 
 class LogModelTest : public QObject
 {
@@ -80,8 +84,8 @@ void LogModelTest::initTestCase()
 
     logService->openBuffer(data, "test.csv", QStringList() << "TestFormat");
     logService->createSession(logService->getLogManager()->getModules(),
-                              firstTime.toStdSysMilliseconds(),
-                              lastTime.toStdSysMilliseconds());
+                              toTimePoint(firstTime),
+                              toTimePoint(lastTime));
 }
 
 void LogModelTest::testInitialLoad()

--- a/tests/ServiceTests.cpp
+++ b/tests/ServiceTests.cpp
@@ -10,6 +10,11 @@
 #include "services/ExportService.h"
 
 
+static std::chrono::system_clock::time_point toTimePoint(const QDateTime &dt)
+{
+    return std::chrono::system_clock::time_point{ std::chrono::milliseconds{ dt.toMSecsSinceEpoch() } };
+}
+
 class ServiceTests : public QObject
 {
     Q_OBJECT
@@ -70,7 +75,7 @@ void ServiceTests::initTestCase()
     app->getFormatManager().addFormat(format);
 
     sessionService->openBuffer(data, "test.log.csv", QStringList() << "TestFormat");
-    sessionService->createSession(sessionService->getLogManager()->getModules(), firstTime.toStdSysMilliseconds(), secondTime.toStdSysMilliseconds());
+    sessionService->createSession(sessionService->getLogManager()->getModules(), toTimePoint(firstTime), toTimePoint(secondTime));
 }
 
 void ServiceTests::cleanupTestCase()
@@ -83,7 +88,7 @@ void ServiceTests::cleanupTestCase()
 
 void ServiceTests::testSessionService()
 {
-    int idx = sessionService->requestIterator(firstTime.toStdSysMilliseconds(), secondTime.toStdSysMilliseconds());
+    int idx = sessionService->requestIterator(toTimePoint(firstTime), toTimePoint(secondTime));
     QSignalSpy spy(sessionService, &SessionService::iteratorCreated);
     QVERIFY(spy.wait(1000));
     auto iterator = sessionService->getIterator(idx);


### PR DESCRIPTION
## Summary
- restore original `parseTime` implementation
- add `LogFilterModel` tests for wildcard and variant list filtering and ensure `FilteredLogModel` creation

## Testing
- `cmake .. -DZLIB_LIBRARY=/usr/lib/x86_64-linux-gnu/libz.so`
- `cmake --build . --target LogFilterModelTest` *(fails: 'parse' is not a member of 'std::chrono')*
- `QT_QPA_PLATFORM=offscreen ./LogFilterModelTest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c16bc97c83238149d24417da554a