### PR TITLE
feat: add bookmarking support to log view

### DIFF
--- a/src/LogView/LogModel.h
+++ b/src/LogView/LogModel.h
@@ -8,6 +8,8 @@
 #include <memory>
 #include <deque>
 #include <set>
+#include <unordered_set>
+#include <unordered_map>
 
 class LogFilter;
 
@@ -71,6 +73,11 @@ public:
     Qt::ItemFlags flags(const QModelIndex& index) const override;
 
     LogService* getService() const;
+
+    void toggleBookmark(const QModelIndex& index);
+    bool isBookmarked(const QModelIndex& index) const;
+    void clearBookmarks();
+    bool hasBookmarks() const;
 
 signals:
     void startPageSwap();
@@ -204,6 +211,15 @@ private:
     std::vector<Format::Field> fields;
     std::unordered_set<QString> modules;
     std::deque<LogItem> logs;
+
+    struct TimePointHash
+    {
+        size_t operator()(const std::chrono::system_clock::time_point& tp) const noexcept
+        {
+            return std::hash<long long>()(tp.time_since_epoch().count());
+        }
+    };
+    std::unordered_map<std::chrono::system_clock::time_point, LogEntry, TimePointHash> bookmarks;
 
     MergeHeapCacheContainer entryCache;
 

--- a/src/LogView/LogView.h
+++ b/src/LogView/LogView.h
@@ -3,6 +3,8 @@
 #include <QAbstractItemModel>
 #include <QTreeView>
 
+class QContextMenuEvent;
+
 class LogModel;
 class LogFilterModel;
 
@@ -30,6 +32,7 @@ private slots:
 
 private:
     virtual void scrollContentsBy(int dx, int dy) override;
+    void contextMenuEvent(QContextMenuEvent* event) override;
 
 private:
     std::optional<QModelIndex> lastScrollPosition;


### PR DESCRIPTION
## Summary
- save bookmarked log entries by timestamp so they persist after log trimming
- add helpers to clear all bookmarks and expose bookmark state to the view
- restore original time parsing and log trimming implementations per review feedback

## Testing
- `cmake -S . -B build -DZLIB_LIBRARY=/usr/lib/x86_64-linux-gnu/libz.so -DZLIB_INCLUDE_DIR=/usr/include`
- `g++ -std=c++20 $(pkg-config --cflags Qt6Core) -I src -c src/LogManagement/LogUtils.cpp` *(fails: 'parse' is not a member of std::chrono)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c0d22e348323993019c45e952c60