### PR TITLE
Fix heap item inconsistency when switching logs

### DIFF
--- a/src/LogManagement/LogEntryIterator.h
+++ b/src/LogManagement/LogEntryIterator.h
@@ -247,10 +247,22 @@ private:
         const auto& format = heapItem.metadata->second.format;
 
         std::optional<QString> line;
-        if (!heapItem.line.isEmpty())
-            line = heapItem.line;
-        if constexpr (!straight)
+        if constexpr (straight)
+        {
+            if (!heapItem.line.isEmpty())
+            {
+                line = heapItem.line;
+                heapItem.line.clear();
+            }
+            else
+            {
+                line = heapItem.log->nextLine();
+            }
+        }
+        else
+        {
             line = heapItem.log->prevLine();
+        }
 
         while (line.has_value())
         {
@@ -368,10 +380,13 @@ private:
             line = (heapItem.log.get()->*(straight ? &Log::nextLine : &Log::prevLine))();
         }
 
-        switchToNextLog(heapItem);
-
         if (!entry.line.isEmpty())
             return entry;
+
+        switchToNextLog(heapItem);
+
+        if (!heapItem.line.isEmpty())
+            return getEntry(heapItem);
         return std::nullopt;
     }
 


### PR DESCRIPTION
## Summary
- ensure HeapItem retains current log context when reaching end-of-file
- defer switching to next log until after pending entry is returned
- recursively fetch first entry of next log once previous log is exhausted

## Testing
- `cmake .. -DBUILD_TESTING=ON` *(fails: Could not find a package configuration file provided by "Qt6")*
- `apt-get install -y qt6-base-dev` *(terminated: installation did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b37e950883239731042ff817f7ae