### PR TITLE
Refactor log creation helper

### DIFF
--- a/src/LogManagement/LogManager.cpp
+++ b/src/LogManagement/LogManager.cpp
@@ -218,8 +218,8 @@ bool LogManager::addFile(DirectoryScanner& scanner, const QString& filename, con
 
     LogMetadata metadata;
     metadata.format = result->format;
-    metadata.fileBuilder = [this, createFileFunc](const QString& filename, const std::shared_ptr<Format>& format) {
-        return std::make_shared<Log>(createLog(filename, createFileFunc, format));
+    metadata.fileBuilder = [createFileFunc](const QString& filename, const std::shared_ptr<Format>& format) {
+        return std::make_shared<Log>(LogManager::createLog(filename, createFileFunc, format));
     };
     metadata.filename = filename;
     scanner.addFile(module, std::move(metadata), result->start, result->end);

--- a/src/LogManagement/LogManager.h
+++ b/src/LogManagement/LogManager.h
@@ -47,7 +47,7 @@ private:
     std::optional<FileDesc> scanLogFile(const QString& filename, std::function<std::unique_ptr<QIODevice>(const QString&)> createFileFunc, const std::vector<std::shared_ptr<Format>>& formats);
     std::chrono::system_clock::time_point getEndTime(const QString& filename, Log& log, const std::shared_ptr<Format>& format);
 
-    Log createLog(const QString& filename, std::function<std::unique_ptr<QIODevice>(const QString&)> createFileFunc, std::shared_ptr<Format> format);
+    static Log createLog(const QString& filename, std::function<std::unique_ptr<QIODevice>(const QString&)> createFileFunc, std::shared_ptr<Format> format);
 
     static void readIntoBuffer(QIODevice& source, QBuffer& targetBuffer);
 


### PR DESCRIPTION
## Summary
- Avoid capturing `this` in `LogManager` fileBuilder lambda by calling a static `createLog`
- Convert `LogManager::createLog` to a static helper

## Testing
- `cmake -DZLIB_LIBRARY=/usr/lib/x86_64-linux-gnu/libz.so -DZLIB_INCLUDE_DIR=/usr/include .. && cmake --build . && ctest` *(fails: `std::chrono::parse` is not a member of `std::chrono`)*

------
https://chatgpt.com/codex/tasks/task_e_68a63a467990832395bbd66857374ea7