### PR TITLE
Adapt timeline histogram to log length

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -10,6 +10,7 @@
 #include "LogView/LogView.h"
 #include "FormatCreation/FormatCreationWizard.h"
 #include "TimelineDialog.h"
+#include "TimeFrameDialog.h"
 #include "services/SessionService.h"
 #include "services/SearchService.h"
 #include "services/ExportService.h"
@@ -183,7 +184,20 @@ void MainWindow::on_actionTimeline_triggered()
 {
     QT_SLOT_BEGIN
 
-    openTimeline();
+    auto app = qobject_cast<Application*>(QApplication::instance());
+    auto sessionService = app->getSessionService();
+    auto sessionPtr = sessionService->getSession();
+    if (!sessionPtr)
+        return;
+
+    QDateTime start = DateTimeFromChronoSystemClock(sessionPtr->getMinTime());
+    QDateTime end = DateTimeFromChronoSystemClock(sessionPtr->getMaxTime());
+
+    TimeFrameDialog frameDialog(start, end, this);
+    if (frameDialog.exec() != QDialog::Accepted)
+        return;
+
+    emit openTimeline(frameDialog.startDateTime(), frameDialog.endDateTime());
 
     QT_SLOT_END
 }

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -60,7 +60,7 @@ signals:
 
     void exportData(const QString& filename, QTreeView* view);
 
-    void openTimeline();
+    void openTimeline(const QDateTime& start, const QDateTime& end);
 
 private:
     void addFormat(const std::string& format);

--- a/src/Statistics/LogHistogram.cpp
+++ b/src/Statistics/LogHistogram.cpp
@@ -1,5 +1,6 @@
 #include "LogHistogram.h"
-
+#include <algorithm>
+#include <cstdint>
 namespace Statistics
 {
 std::vector<Bucket> LogHistogram::calculate(Session& session,
@@ -31,6 +32,21 @@ std::vector<Bucket> LogHistogram::calculate(Session& session,
     }
 
     return result;
+}
+
+std::chrono::system_clock::duration LogHistogram::suggestBucketSize(
+        const std::chrono::system_clock::time_point& start,
+        const std::chrono::system_clock::time_point& end,
+        std::size_t maxBuckets)
+{
+    if (end <= start || maxBuckets == 0)
+        return std::chrono::seconds(1);
+
+    auto diff = end - start;
+    auto totalSeconds = std::chrono::duration_cast<std::chrono::seconds>(diff).count();
+    auto bucketSeconds = std::max<std::int64_t>(1,
+        (totalSeconds + static_cast<std::int64_t>(maxBuckets) - 1) / static_cast<std::int64_t>(maxBuckets));
+    return std::chrono::seconds(bucketSeconds);
 }
 }
 

--- a/src/Statistics/LogHistogram.h
+++ b/src/Statistics/LogHistogram.h
@@ -20,6 +20,11 @@ public:
                                          const std::chrono::system_clock::time_point& start,
                                          const std::chrono::system_clock::time_point& end,
                                          const std::chrono::system_clock::duration& bucketSize);
+
+    static std::chrono::system_clock::duration suggestBucketSize(
+        const std::chrono::system_clock::time_point& start,
+        const std::chrono::system_clock::time_point& end,
+        std::size_t maxBuckets = 120);
 };
 }
 

--- a/src/TimeFrameDialog.cpp
+++ b/src/TimeFrameDialog.cpp
@@ -1,0 +1,47 @@
+#include "TimeFrameDialog.h"
+
+#include <QDateTimeEdit>
+#include <QDialogButtonBox>
+#include <QVBoxLayout>
+
+TimeFrameDialog::TimeFrameDialog(const QDateTime& start, const QDateTime& end, QWidget* parent)
+    : QDialog(parent)
+{
+    auto layout = new QVBoxLayout(this);
+    startEdit = new QDateTimeEdit(start, this);
+    endEdit = new QDateTimeEdit(end, this);
+    startEdit->setCalendarPopup(true);
+    endEdit->setCalendarPopup(true);
+    startEdit->setMaximumDateTime(end);
+    endEdit->setMinimumDateTime(start);
+    connect(startEdit, &QDateTimeEdit::dateTimeChanged, this, &TimeFrameDialog::onStartChanged);
+    connect(endEdit, &QDateTimeEdit::dateTimeChanged, this, &TimeFrameDialog::onEndChanged);
+    layout->addWidget(startEdit);
+    layout->addWidget(endEdit);
+
+    buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    layout->addWidget(buttonBox);
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+}
+
+QDateTime TimeFrameDialog::startDateTime() const
+{
+    return startEdit->dateTime();
+}
+
+QDateTime TimeFrameDialog::endDateTime() const
+{
+    return endEdit->dateTime();
+}
+
+void TimeFrameDialog::onStartChanged(const QDateTime& dt)
+{
+    endEdit->setMinimumDateTime(dt);
+}
+
+void TimeFrameDialog::onEndChanged(const QDateTime& dt)
+{
+    startEdit->setMaximumDateTime(dt);
+}
+

--- a/src/TimeFrameDialog.h
+++ b/src/TimeFrameDialog.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QDialog>
+
+class QDateTimeEdit;
+class QDialogButtonBox;
+
+class TimeFrameDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    TimeFrameDialog(const QDateTime& start, const QDateTime& end, QWidget* parent = nullptr);
+
+    QDateTime startDateTime() const;
+    QDateTime endDateTime() const;
+
+private slots:
+    void onStartChanged(const QDateTime& dt);
+    void onEndChanged(const QDateTime& dt);
+
+private:
+    QDateTimeEdit* startEdit;
+    QDateTimeEdit* endEdit;
+    QDialogButtonBox* buttonBox;
+};
+

--- a/src/services/TimelineService.h
+++ b/src/services/TimelineService.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <QDateTime>
 #include <vector>
 #include "Statistics/LogHistogram.h"
 
@@ -20,7 +21,7 @@ signals:
     void handleError(const QString& message);
 
 public slots:
-    void showTimeline();
+    void showTimeline(const QDateTime& start, const QDateTime& end);
 
 private:
     SessionService* sessionService;

--- a/tests/LogHistogramTest.cpp
+++ b/tests/LogHistogramTest.cpp
@@ -1,0 +1,29 @@
+#include <QtTest/QtTest>
+
+#include "Statistics/LogHistogram.h"
+
+using namespace std::chrono;
+
+class LogHistogramTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testSuggestBucketSize();
+};
+
+void LogHistogramTest::testSuggestBucketSize()
+{
+    auto start = system_clock::time_point{};
+    auto end = start + minutes(10);
+    auto bucket = Statistics::LogHistogram::suggestBucketSize(start, end, 5);
+    QCOMPARE(bucket, minutes(2));
+
+    auto shortEnd = start + seconds(30);
+    auto bucket2 = Statistics::LogHistogram::suggestBucketSize(start, shortEnd, 100);
+    QCOMPARE(bucket2, seconds(1));
+}
+
+QTEST_APPLESS_MAIN(LogHistogramTest)
+#include "LogHistogramTest.moc"
+


### PR DESCRIPTION
## Summary
- add adaptive bucket sizing for log histograms
- allow selecting a custom time frame before building the timeline
- collect the time frame in MainWindow and pass it to the timeline service
- cover bucket size calculation with unit tests

## Testing
- `cmake -S . -B build -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6` *(fails: Could not find a package configuration file provided by "Qt6")*
- `sudo apt-get update` *(warns: Failed to fetch https://mise.jdx.dev/deb/dists/stable/InRelease)*
- `sudo apt-get install -y qt6-base-dev libboost-dev libquazip-qt6-dev` *(fails: Unable to locate package libquazip-qt6-dev)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c958056083238bcd9c7af5491285