### PR TITLE
Fix scroll jump after block swap

### DIFF
--- a/src/LogView/LogView.cpp
+++ b/src/LogView/LogView.cpp
@@ -167,15 +167,21 @@ void LogView::handleFirstLineRemoving(const QModelIndex& parent, int first, int 
     if (lastScrollPosition)
     {
         if (parent.isValid() || lastScrollPosition->row() < first)
+        {
+            lastScrollPosition.reset();
             return;
+        }
 
         auto* logModel = qobject_cast<LogModel*>(model());
         auto* proxyModel = qobject_cast<QAbstractProxyModel*>(model());
         if (proxyModel)
             logModel = qobject_cast<LogModel*>(proxyModel->sourceModel());
 
-        auto newIndex = logModel->index(lastScrollPosition->row() - last + first, lastScrollPosition->column());
-        scrollTo(proxyModel->mapFromSource(newIndex), QAbstractItemView::ScrollHint::PositionAtTop);
+        int count = last - first + 1;
+        auto newIndex = logModel->index(lastScrollPosition->row() - count,
+                                      lastScrollPosition->column());
+        scrollTo(proxyModel->mapFromSource(newIndex),
+                 QAbstractItemView::ScrollHint::PositionAtTop);
         lastScrollPosition.reset();
     }
     else
@@ -191,15 +197,21 @@ void LogView::handleFirstLineAddition(const QModelIndex& parent, int first, int 
     if (lastScrollPosition)
     {
         if (parent.isValid() || lastScrollPosition->row() < first)
+        {
+            lastScrollPosition.reset();
             return;
+        }
 
         auto* logModel = qobject_cast<LogModel*>(model());
         auto* proxyModel = qobject_cast<QAbstractProxyModel*>(model());
         if (proxyModel)
             logModel = qobject_cast<LogModel*>(proxyModel->sourceModel());
 
-        auto newIndex = logModel->index(lastScrollPosition->row() + last - first, lastScrollPosition->column());
-        scrollTo(proxyModel->mapFromSource(newIndex), QAbstractItemView::ScrollHint::PositionAtTop);
+        int count = last - first + 1;
+        auto newIndex = logModel->index(lastScrollPosition->row() + count,
+                                      lastScrollPosition->column());
+        scrollTo(proxyModel->mapFromSource(newIndex),
+                 QAbstractItemView::ScrollHint::PositionAtTop);
         lastScrollPosition.reset();
     }
     else


### PR DESCRIPTION
## Summary
- keep viewport stable when blocks are swapped by adjusting index calculations based on actual rows inserted or removed
- clear stored scroll position when the update doesn't affect the first visible row

## Testing
- `cmake -S . -B build -DZLIB_LIBRARY=/usr/lib/x86_64-linux-gnu/libz.so -DZLIB_INCLUDE_DIR=/usr/include`
- `cmake --build build` *(fails: ‘parse’ is not a member of ‘std::chrono’)*

------
https://chatgpt.com/codex/tasks/task_e_68a70f890d8c8323ad259ec8a403c118