### PR TITLE
Allow resizing between log view and bookmark table

### DIFF
--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -16,13 +16,16 @@
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
-     <widget class="LogView" name="logView"/>
-    </item>
-    <item>
-     <widget class="BookmarkTable" name="bookmarkTable">
-      <property name="visible">
-       <bool>false</bool>
+     <widget class="QSplitter" name="logSplitter">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
       </property>
+      <widget class="LogView" name="logView"/>
+      <widget class="BookmarkTable" name="bookmarkTable">
+       <property name="visible">
+        <bool>false</bool>
+       </property>
+      </widget>
      </widget>
     </item>
     <item>


### PR DESCRIPTION
## Summary
- replace the fixed layout of the log view and bookmark table with a vertical splitter so the divider can be moved

## Testing
- `cmake -S . -B build -DZLIB_INCLUDE_DIR=/usr/include -DZLIB_LIBRARY=/usr/lib/x86_64-linux-gnu/libz.so`
- `cmake --build build` *(fails: ‘std::chrono::parse’ is not a member of ‘std::chrono’)*

------
https://chatgpt.com/codex/tasks/task_e_68a72b6dd46083238f4a593243a39f88