### PR TITLE
Persist bookmark table size in settings

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -104,6 +104,9 @@ MainWindow::~MainWindow()
     Settings settings;
     settings.setValue(objectName() + "/geometry", saveGeometry());
     settings.setValue(objectName() + "/state", saveState());
+    auto sizes = ui->logSplitter->sizes();
+    if (sizes.size() >= 2)
+        settings.setValue(objectName() + "/bookmarkTableSize", sizes[1]);
 
     delete ui;
 }
@@ -363,7 +366,34 @@ void MainWindow::on_actionFiltered_export_triggered()
 void MainWindow::on_actionShow_bookmarks_triggered()
 {
     QT_SLOT_BEGIN
-    ui->bookmarkTable->setVisible(ui->actionShow_bookmarks->isChecked());
+    bool checked = ui->actionShow_bookmarks->isChecked();
+    if (checked)
+    {
+        ui->bookmarkTable->setVisible(true);
+        Settings settings;
+        int bookmarkSize = settings.value(objectName() + "/bookmarkTableSize", 100).toInt();
+        auto sizes = ui->logSplitter->sizes();
+        if (sizes.size() >= 2)
+        {
+            int total = sizes[0] + sizes[1];
+            if (bookmarkSize < total)
+            {
+                sizes[1] = bookmarkSize;
+                sizes[0] = total - bookmarkSize;
+                ui->logSplitter->setSizes(sizes);
+            }
+        }
+    }
+    else
+    {
+        auto sizes = ui->logSplitter->sizes();
+        if (sizes.size() >= 2)
+        {
+            Settings settings;
+            settings.setValue(objectName() + "/bookmarkTableSize", sizes[1]);
+        }
+        ui->bookmarkTable->setVisible(false);
+    }
     QT_SLOT_END
 }
 


### PR DESCRIPTION
## Summary
- Restore bookmark table to a smaller default height when shown
- Save bookmark table height in QSettings when hidden and on exit

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6)*
- `apt-get install -y qt6-base-dev` *(terminated: installation incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_68a77a0cb4508323af5d9e74eccd9de4