### PR TITLE
Add blacklist filter mode for log filters

### DIFF
--- a/src/LogFilter.cpp
+++ b/src/LogFilter.cpp
@@ -1,11 +1,16 @@
 #include "LogFilter.h"
 
 
-LogFilter::LogFilter(const std::unordered_map<int, QRegularExpression>& columnFilters, const std::unordered_map<int, std::unordered_set<QString>>& variants, const QStringList& fields, const std::unordered_set<QString>& modules) :
+LogFilter::LogFilter(const std::unordered_map<int, RegexFilter>& columnFilters,
+                     const std::unordered_map<int, VariantFilter>& variants,
+                     const QStringList& fields,
+                     const std::unordered_set<QString>& modules,
+                     FilterType modulesType) :
     columnFilters(columnFilters),
     variants(variants),
     fields(fields),
-    modules(modules)
+    modules(modules),
+    modulesType(modulesType)
 {}
 
 bool LogFilter::isEmpty() const
@@ -15,15 +20,26 @@ bool LogFilter::isEmpty() const
 
 bool LogFilter::check(const LogEntry& entry) const
 {
-    if (!modules.empty() && !modules.contains(entry.module))
-        return false;
+    if (!modules.empty())
+    {
+        bool contains = modules.contains(entry.module);
+        if (modulesType == FilterType::Whitelist && !contains)
+            return false;
+        if (modulesType == FilterType::Blacklist && contains)
+            return false;
+    }
 
     for (const auto& filter : columnFilters)
     {
         int column = filter.first;
-        const QRegularExpression& rx = filter.second;
+        const QRegularExpression& rx = filter.second.regex;
         auto it = entry.values.find(fields[column]);
-        if (it == entry.values.end() || !rx.pattern().isEmpty() && !rx.match(it->second.toString()).hasMatch())
+        if (rx.pattern().isEmpty())
+            continue;
+        bool match = it != entry.values.end() && rx.match(it->second.toString()).hasMatch();
+        if (filter.second.type == FilterType::Whitelist && !match)
+            return false;
+        if (filter.second.type == FilterType::Blacklist && match)
             return false;
     }
 
@@ -31,7 +47,10 @@ bool LogFilter::check(const LogEntry& entry) const
     {
         int column = filter.first;
         auto it = entry.values.find(fields[column]);
-        if (it == entry.values.end() || variants.at(column).find(it->second.toString()) == variants.at(column).end())
+        bool contains = it != entry.values.end() && filter.second.values.find(it->second.toString()) != filter.second.values.end();
+        if (filter.second.type == FilterType::Whitelist && !contains)
+            return false;
+        if (filter.second.type == FilterType::Blacklist && contains)
             return false;
     }
 
@@ -42,16 +61,19 @@ void LogFilter::apply(const LogFilter& other)
 {
     for (const auto& filter : other.columnFilters)
     {
-        if (!filter.second.pattern().isEmpty() && filter.second.isValid())
+        if (!filter.second.regex.pattern().isEmpty() && filter.second.regex.isValid())
             columnFilters[filter.first] = filter.second;
     }
 
     for (const auto& variant : other.variants)
     {
-        if (!variant.second.empty())
+        if (!variant.second.values.empty())
             variants[variant.first] = variant.second;
     }
 
     if (!other.modules.empty())
+    {
         modules = other.modules;
+        modulesType = other.modulesType;
+    }
 }

--- a/src/LogFilter.h
+++ b/src/LogFilter.h
@@ -6,15 +6,37 @@
 
 #include <unordered_set>
 
+#ifndef FILTER_TYPE_ENUM
+#define FILTER_TYPE_ENUM
+enum class FilterType
+{
+    Whitelist,
+    Blacklist
+};
+Q_DECLARE_METATYPE(FilterType);
+#endif
+
+struct RegexFilter
+{
+    QRegularExpression regex;
+    FilterType type = FilterType::Whitelist;
+};
+
+struct VariantFilter
+{
+    std::unordered_set<QString> values;
+    FilterType type = FilterType::Whitelist;
+};
 
 class LogFilter
 {
 public:
     LogFilter() = default;
-    LogFilter(const std::unordered_map<int, QRegularExpression>& columnFilters,
-              const std::unordered_map<int, std::unordered_set<QString>>& variants,
+    LogFilter(const std::unordered_map<int, RegexFilter>& columnFilters,
+              const std::unordered_map<int, VariantFilter>& variants,
               const QStringList& fields,
-              const std::unordered_set<QString>& modules);
+              const std::unordered_set<QString>& modules,
+              FilterType modulesType = FilterType::Whitelist);
 
     bool isEmpty() const;
 
@@ -23,10 +45,11 @@ public:
     void apply(const LogFilter& other);
 
 private:
-    std::unordered_map<int, QRegularExpression> columnFilters;
-    std::unordered_map<int, std::unordered_set<QString>> variants;
+    std::unordered_map<int, RegexFilter> columnFilters;
+    std::unordered_map<int, VariantFilter> variants;
     QStringList fields;
     std::unordered_set<QString> modules;
+    FilterType modulesType = FilterType::Whitelist;
 };
 
 Q_DECLARE_METATYPE(LogFilter);

--- a/src/LogView/LogFilterModel.h
+++ b/src/LogView/LogFilterModel.h
@@ -13,6 +13,16 @@ class LogModel;
 class FilteredLogModel;
 
 
+#ifndef FILTER_TYPE_ENUM
+#define FILTER_TYPE_ENUM
+enum class FilterType
+{
+    Whitelist,
+    Blacklist
+};
+Q_DECLARE_METATYPE(FilterType);
+#endif
+
 class LogFilterModel : public QSortFilterProxyModel
 {
     Q_OBJECT
@@ -23,6 +33,8 @@ public:
     void setFilterWildcard(int column, const QString& pattern);
     void setFilterRegularExpression(int column, const QString& pattern);
     void setVariantList(int column, const QStringList& values);
+    void setFilterMode(int column, FilterType type);
+    FilterType filterMode(int column) const;
 
     void setSourceModel(QAbstractItemModel* sourceModel) override;
 
@@ -40,8 +52,8 @@ private:
     void updateSourceModel();
     void clearFilters();
 
-    std::unordered_map<int, QRegularExpression> columnFilters;
-    std::unordered_map<int, std::unordered_set<QString>> variants;
+    std::unordered_map<int, RegexFilter> columnFilters;
+    std::unordered_map<int, VariantFilter> variants;
     std::unordered_map<int, double> filterEstimates;
 
     LogModel* baseModel = nullptr;

--- a/src/LogView/MultiSelectComboBox.h
+++ b/src/LogView/MultiSelectComboBox.h
@@ -2,6 +2,9 @@
 
 #include <QComboBox>
 #include <QListWidget>
+#include <QAction>
+
+#include "LogFilterModel.h"
 
 
 class MultiSelectComboBox : public QComboBox
@@ -19,9 +22,12 @@ public:
     void SetSearchBarPlaceHolderText(const QString& aPlaceHolderText);
     void SetPlaceHolderText(const QString& aPlaceHolderText);
     void ResetSelection();
+    void setMode(FilterType mode);
+    FilterType mode() const { return mMode; }
 
 signals:
     void selectionChanged();
+    void filterModeChanged(FilterType mode);
 
 public slots:
     void clear();
@@ -37,10 +43,13 @@ private:
     void stateChanged(int aState);
     void onSearch(const QString& aSearchString);
     void itemClicked(int aIndex);
+    void updateModeAction();
 
     QListWidget* mListWidget;
     QLineEdit* mLineEdit;
     QLineEdit* mSearchBar;
     QVariantList mCurrentData;
     QStringList mItems;
+    QAction* mModeAction;
+    FilterType mMode = FilterType::Whitelist;
 };


### PR DESCRIPTION
## Summary
- allow whitelist/blacklist modes for column and variant filters
- propagate filter mode through export and checking
- expose filter mode toggles with tool buttons in header and combo box UI

## Testing
- `cmake -S . -B build -DZLIB_LIBRARY=/usr/lib/x86_64-linux-gnu/libz.so -DZLIB_INCLUDE_DIR=/usr/include` *(failed: Could not find a package configuration file provided by "Qt6")*
- `cmake --build build` *(failed: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_68ab48247a288323913aabaf270f7ac3