### PR TITLE
feat: add search mode combo and separate results widget

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -16,6 +16,7 @@
 #include "services/ExportService.h"
 #include "services/TimelineService.h"
 #include "BookmarkTable.h"
+#include "SearchResultsWidget.h"
 
 #include <utility>
 #include <QScrollBar>
@@ -42,11 +43,13 @@ MainWindow::MainWindow(QWidget *parent) :
     statusBar()->addPermanentWidget(progressBar);
 
     ui->searchBar->hide();
+    ui->searchResults->hide();
 
     ui->bookmarkTable->hide();
     connect(ui->bookmarkTable, &BookmarkTable::bookmarkActivated, ui->logView, &LogView::bookmarkActivated);
 
     searchController = new SearchController(ui->searchBar, ui->logView, this);
+    connect(searchController, &SearchController::searchResults, ui->searchResults, &SearchResultsWidget::showResults);
     connect(ui->searchBar, &SearchBar::handleError, this, &MainWindow::handleError);
 
     Settings settings;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -51,7 +51,6 @@ MainWindow::MainWindow(QWidget *parent) :
 
     searchController = new SearchController(ui->searchBar, ui->logView, this);
     connect(searchController, &SearchController::searchResults, ui->searchResults, &SearchResultsWidget::showResults);
-    connect(ui->searchBar, &SearchBar::handleError, this, &MainWindow::handleError);
 
     Settings settings;
     qDebug() << "Settings location: " << settings.fileName();
@@ -117,6 +116,7 @@ MainWindow::MainWindow(QWidget *parent) :
 
     connect(ui->searchBar, &SearchBar::handleError, this, &MainWindow::handleError);
     connect(ui->logView, &LogView::handleError, this, &MainWindow::handleError);
+    connect(ui->searchResults, &SearchResultsWidget::handleError, this, &MainWindow::handleError);
 }
 
 MainWindow::~MainWindow()

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -31,6 +31,9 @@
     <item>
      <widget class="SearchBar" name="searchBar" native="true"/>
     </item>
+    <item>
+     <widget class="SearchResultsWidget" name="searchResults" native="true"/>
+    </item>
    </layout>
   </widget>
   <widget class="QMenuBar" name="menubar">
@@ -170,6 +173,12 @@
    <class>SearchBar</class>
    <extends>QWidget</extends>
    <header>SearchBar.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>SearchResultsWidget</class>
+   <extends>QWidget</extends>
+   <header>SearchResultsWidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/SearchBar.cpp
+++ b/src/SearchBar.cpp
@@ -44,21 +44,29 @@ void SearchBar::on_toolButton_clicked()
     QT_SLOT_END
 }
 
-void SearchBar::on_bLocalSearch_clicked()
+void SearchBar::on_bFindNext_clicked()
 {
     QT_SLOT_BEGIN
 
-    localSearch(ui->lineEdit->text(), ui->cbLastColumnSearch->isChecked(), ui->cbRegExpSuppor->isChecked(), ui->cbBackward->isChecked(), ui->cbUseFilters->isChecked());
+    bool local = ui->cbSearchMode->currentIndex() == 0;
+    if (local)
+        emit localSearch(ui->lineEdit->text(), ui->cbLastColumnSearch->isChecked(), ui->cbRegExpSuppor->isChecked(), ui->cbBackward->isChecked(), ui->cbUseFilters->isChecked(), false);
+    else
+        emit commonSearch(ui->lineEdit->text(), ui->cbLastColumnSearch->isChecked(), ui->cbRegExpSuppor->isChecked(), ui->cbBackward->isChecked(), ui->cbUseFilters->isChecked(), false);
 
     QT_SLOT_END
 }
 
 
-void SearchBar::on_bCommonSearch_clicked()
+void SearchBar::on_bFindAll_clicked()
 {
     QT_SLOT_BEGIN
 
-    commonSearch(ui->lineEdit->text(), ui->cbLastColumnSearch->isChecked(), ui->cbRegExpSuppor->isChecked(), ui->cbBackward->isChecked(), ui->cbUseFilters->isChecked());
+    bool local = ui->cbSearchMode->currentIndex() == 0;
+    if (local)
+        emit localSearch(ui->lineEdit->text(), ui->cbLastColumnSearch->isChecked(), ui->cbRegExpSuppor->isChecked(), ui->cbBackward->isChecked(), ui->cbUseFilters->isChecked(), true);
+    else
+        emit commonSearch(ui->lineEdit->text(), ui->cbLastColumnSearch->isChecked(), ui->cbRegExpSuppor->isChecked(), ui->cbBackward->isChecked(), ui->cbUseFilters->isChecked(), true);
 
     QT_SLOT_END
 }

--- a/src/SearchBar.h
+++ b/src/SearchBar.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QWidget>
+#include <QStringList>
 
 namespace Ui {
 class SearchBar;
@@ -15,16 +16,16 @@ public:
     ~SearchBar();
 
 signals:
-    void localSearch(const QString& searchTerm, bool lastColumn, bool regexEnabled, bool backward, bool useFilters);
-    void commonSearch(const QString& searchTerm, bool lastColumn, bool regexEnabled, bool backward, bool useFilters);
+    void localSearch(const QString& searchTerm, bool lastColumn, bool regexEnabled, bool backward, bool useFilters, bool findAll);
+    void commonSearch(const QString& searchTerm, bool lastColumn, bool regexEnabled, bool backward, bool useFilters, bool findAll);
 
     void handleError(const QString& message);
 
 private slots:
     void on_toolButton_clicked();
 
-    void on_bLocalSearch_clicked();
-    void on_bCommonSearch_clicked();
+    void on_bFindNext_clicked();
+    void on_bFindAll_clicked();
 
 private:
     Ui::SearchBar *ui;

--- a/src/SearchBar.ui
+++ b/src/SearchBar.ui
@@ -64,9 +64,23 @@
        <widget class="QLineEdit" name="lineEdit"/>
       </item>
       <item>
-       <widget class="QToolButton" name="bLocalSearch">
+       <widget class="QComboBox" name="cbSearchMode">
+        <item>
+         <property name="text">
+          <string>Log view</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Global</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="bFindNext">
         <property name="toolTip">
-         <string>Search in log view</string>
+         <string>Find next</string>
         </property>
         <property name="text">
          <string/>
@@ -78,9 +92,9 @@
        </widget>
       </item>
       <item>
-       <widget class="QToolButton" name="bCommonSearch">
+       <widget class="QToolButton" name="bFindAll">
         <property name="toolTip">
-         <string>Global search</string>
+         <string>Find all</string>
         </property>
         <property name="text">
          <string/>

--- a/src/SearchController.h
+++ b/src/SearchController.h
@@ -6,6 +6,7 @@
 
 #include <QObject>
 #include <QAbstractItemView>
+#include <QStringList>
 #include <chrono>
 
 
@@ -26,16 +27,17 @@ signals:
     void startGlobalSearchWithFilter(const std::chrono::system_clock::time_point& startTime, const QString& searchTerm, bool lastColumn, bool regexEnabled, bool backward, const LogFilter& filter);
 
     void handleError(const QString& message);
+    void searchResults(const QStringList& results);
 
 public slots:
-    void localSearch(const QString& searchTerm, bool lastColumn, bool regexEnabled, bool backward, bool useFilters);
-    void commonSearch(const QString& searchTerm, bool lastColumn, bool regexEnabled, bool backward, bool useFilters);
+    void localSearch(const QString& searchTerm, bool lastColumn, bool regexEnabled, bool backward, bool useFilters, bool findAll);
+    void commonSearch(const QString& searchTerm, bool lastColumn, bool regexEnabled, bool backward, bool useFilters, bool findAll);
 
     void handleSearchResult(const QString& searchTerm, const std::chrono::system_clock::time_point& entryTime);
     void handleLoadingFinished(const QModelIndex& index);
 
 private:
-    void search(const QModelIndex& from, const QString& searchTerm, bool lastColumn, bool regexEnabled, bool backward, bool useFilters, bool globalSearch);
+    void search(const QModelIndex& from, const QString& searchTerm, bool lastColumn, bool regexEnabled, bool backward, bool useFilters, bool globalSearch, bool findAll);
 
 private:
     QAbstractItemView* logView;

--- a/src/SearchResultsWidget.cpp
+++ b/src/SearchResultsWidget.cpp
@@ -3,9 +3,10 @@
 
 #include "Utils.h"
 
-SearchResultsWidget::SearchResultsWidget(QWidget* parent)
-    : QWidget(parent),
-      ui(new Ui::SearchResultsWidget)
+
+SearchResultsWidget::SearchResultsWidget(QWidget* parent) :
+    QWidget(parent),
+    ui(new Ui::SearchResultsWidget)
 {
     ui->setupUi(this);
     hide();

--- a/src/SearchResultsWidget.cpp
+++ b/src/SearchResultsWidget.cpp
@@ -1,0 +1,43 @@
+#include "SearchResultsWidget.h"
+#include "ui_SearchResultsWidget.h"
+
+#include "Utils.h"
+
+SearchResultsWidget::SearchResultsWidget(QWidget* parent)
+    : QWidget(parent),
+      ui(new Ui::SearchResultsWidget)
+{
+    ui->setupUi(this);
+    hide();
+}
+
+SearchResultsWidget::~SearchResultsWidget()
+{
+    delete ui;
+}
+
+void SearchResultsWidget::showResults(const QStringList& results)
+{
+    QT_SLOT_BEGIN
+
+    ui->lwResults->clear();
+    if (results.isEmpty())
+    {
+        hide();
+    }
+    else
+    {
+        ui->lwResults->addItems(results);
+        show();
+    }
+
+    QT_SLOT_END
+}
+
+void SearchResultsWidget::on_bHideResults_clicked()
+{
+    QT_SLOT_BEGIN
+    hide();
+    QT_SLOT_END
+}
+

--- a/src/SearchResultsWidget.h
+++ b/src/SearchResultsWidget.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QWidget>
+#include <QStringList>
+
+namespace Ui {
+class SearchResultsWidget;
+}
+
+class SearchResultsWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit SearchResultsWidget(QWidget* parent = nullptr);
+    ~SearchResultsWidget();
+
+public slots:
+    void showResults(const QStringList& results);
+
+private slots:
+    void on_bHideResults_clicked();
+
+private:
+    Ui::SearchResultsWidget* ui;
+};
+

--- a/src/SearchResultsWidget.h
+++ b/src/SearchResultsWidget.h
@@ -3,6 +3,7 @@
 #include <QWidget>
 #include <QStringList>
 
+
 namespace Ui {
 class SearchResultsWidget;
 }
@@ -15,6 +16,9 @@ public:
     explicit SearchResultsWidget(QWidget* parent = nullptr);
     ~SearchResultsWidget();
 
+signals:
+    void handleError(const QString& msg);
+
 public slots:
     void showResults(const QStringList& results);
 
@@ -24,4 +28,3 @@ private slots:
 private:
     Ui::SearchResultsWidget* ui;
 };
-

--- a/src/SearchResultsWidget.ui
+++ b/src/SearchResultsWidget.ui
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SearchResultsWidget</class>
+ <widget class="QWidget" name="SearchResultsWidget">
+  <property name="visible">
+   <bool>false</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QToolButton" name="bHideResults">
+     <property name="toolTip">
+      <string>Hide results</string>
+     </property>
+     <property name="text">
+      <string>x</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListWidget" name="lwResults"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
## Summary
- add dedicated `SearchResultsWidget` to show and hide search matches
- strip results list from `SearchBar` so it only handles search controls
- wire `MainWindow` and controller to populate the standalone results widget
- refactor slots to invoke `QT_SLOT_END` only once at the end

## Testing
- `cmake -S . -B build -DZLIB_LIBRARY=/usr/lib/x86_64-linux-gnu/libz.so -DZLIB_INCLUDE_DIR=/usr/include` *(fails: Could not find a package configuration file provided by "Qt6")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68af0cfcae108323a379f09d59144c9d